### PR TITLE
デフォルトゴールの扱いを改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ DEFAULT_GOALS  ?= fmt set-license go-licenses-check goimports lint test build
 include includes/go/common.mk
 include includes/go/simple.mk
 
-# toolsゴールを追加(sacloudプロダクト向け日次CIを行うプロジェクトでは必須)
-tools: dev-tools
+# ゴールを追加
+default: $(DEFAULT_GOALS)
+tools: dev-tools # toolsゴールはsacloudプロダクト向け日次CIを行うプロジェクトでは必須
 ```
 
 #### 更新

--- a/go/common.mk
+++ b/go/common.mk
@@ -22,7 +22,7 @@ DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
 GOLANG_CI_LINT_VERSION  ?= v1.46.2
 TEXTLINT_ACTION_VERSION ?= v0.0.1
 
-default: $(DEFAULT_GOALS)
+.DEFAULT_GOAL = default
 
 .PHONY: test
 test:

--- a/go/single.mk
+++ b/go/single.mk
@@ -36,3 +36,5 @@ $(BIN): $(GO_FILES) go.mod go.sum
 clean:
 	@echo "cleaning..."
 	rm -rf $(BIN)
+
+DEFAULT_GOALS += build


### PR DESCRIPTION
利用するプロジェクト側で`default`ゴールを定義することにより、必要な*.mkをインクルードするだけでデフォルトゴールが変わるようにする。