### PR TITLE
lint-textから-iを除去

### DIFF
--- a/go/common.mk
+++ b/go/common.mk
@@ -70,7 +70,7 @@ lint-go:
 textlint: lint-text
 lint-text:
 	@echo "running textlint..."
-	@docker run -it --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
+	@docker run -t --rm -v $$PWD:/work -w /work ghcr.io/sacloud/textlint-action:$(TEXTLINT_ACTION_VERSION) .
 
 .PHONY: lint-action
 lint-action:


### PR DESCRIPTION
GitHub Actionsなどから実行する際に`the input device is not a TTY`エラーを防ぐために-Iを除去する。